### PR TITLE
Actualizar versiones de librerías

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
+    <option name="version" value="1.9.20" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.4"
     }
     packaging {
         resources {
@@ -71,55 +71,67 @@ task<JacocoReport>("codeCoverageReportDebug") {
     executionData.setFrom("${project.buildDir}/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
 }
 
+ksp {
+    arg("room.generateKotlin", "true")
+}
+
 dependencies {
+    val coreVersion = "1.12.0"
     val lifecycleVersion = "2.6.2"
-    val navVersion = "2.7.4"
+    val activityVersion = "1.8.0"
+    val navVersion = "2.7.5"
     val testJunitVersion = "1.1.5"
-    val composeBomVersion = "2023.10.00"
-    val roomVersion = "2.5.2"
+    val composeBomVersion = "2023.10.01"
+    val roomVersion = "2.6.0"
     val fakerVersion = "1.15.0"
     val mockkVersion = "1.13.8"
     val datastoreVersion = "1.0.0"
+    val junitVersion = "4.13.2"
+    val coroutinesTestVersion = "1.7.3"
+    val glideVersion = "5.0.0-rc01"
+    val glideComposeVersion = "1.0.0-beta01"
+    val volleyVersion = "1.2.1"
+    val gsonVersion = "2.10.1"
+    val desugarVersion = "2.0.4"
 
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:$desugarVersion")
 
-    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.core:core-ktx:$coreVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycleVersion")
-    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation("androidx.activity:activity-compose:$activityVersion")
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.navigation:navigation-compose:$navVersion")
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    implementation("androidx.datastore:datastore-preferences:$datastoreVersion")
+    implementation("me.omico.compose:compose-material3-pullrefresh")
+    implementation("com.github.bumptech.glide:glide:$glideVersion")
+    implementation("com.github.bumptech.glide:compose:$glideComposeVersion")
+    implementation("com.android.volley:volley:$volleyVersion")
+    implementation("com.google.code.gson:gson:$gsonVersion")
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    annotationProcessor("androidx.room:room-compiler:$roomVersion")
+
+    ksp("com.github.bumptech.glide:ksp:$glideVersion")
+    ksp("androidx.room:room-compiler:$roomVersion")
+
+    testImplementation("io.github.serpro69:kotlin-faker:$fakerVersion")
+    testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("junit:junit:$junitVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesTestVersion")
+
     androidTestImplementation("androidx.test.ext:junit:$testJunitVersion")
     androidTestImplementation("androidx.test.ext:junit-ktx:$testJunitVersion")
     androidTestImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    debugImplementation("androidx.compose.ui:ui-test-manifest")
-    implementation("androidx.datastore:datastore-preferences:$datastoreVersion")
-
-    implementation("me.omico.compose:compose-material3-pullrefresh")
-
-    implementation("com.github.bumptech.glide:glide:5.0.0-rc01")
-    ksp("com.github.bumptech.glide:ksp:5.0.0-rc01")
-    implementation("com.github.bumptech.glide:compose:1.0.0-beta01")
-
-    implementation("com.android.volley:volley:1.2.1")
-
-    implementation("com.google.code.gson:gson:2.10.1")
-
-    implementation("androidx.room:room-runtime:$roomVersion")
-    annotationProcessor("androidx.room:room-compiler:$roomVersion")
-    ksp("androidx.room:room-compiler:$roomVersion")
-    implementation("androidx.room:room-ktx:$roomVersion")
-
-    testImplementation("io.github.serpro69:kotlin-faker:$fakerVersion")
-    testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.10" apply false
-    id("com.google.devtools.ksp") version "1.8.10-1.0.9" apply false
+    id("com.android.application") version "8.1.3" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
+    id("com.google.devtools.ksp") version "1.9.20-1.0.14" apply false
 }

--- a/libraries/androidx-compose-material3-pullrefresh/library/local.properties
+++ b/libraries/androidx-compose-material3-pullrefresh/library/local.properties
@@ -1,4 +1,4 @@
-project.android.gradle.plugin.version=8.1.2
-project.compose.bom.version=2023.10.00
-project.compose.compiler.version=1.4.3
-project.kotlin.version=1.8.10
+project.android.gradle.plugin.version=8.1.3
+project.compose.bom.version=2023.10.01
+project.compose.compiler.version=1.5.4
+project.kotlin.version=1.9.20


### PR DESCRIPTION
Soluciona 14 code smells reportados por SonarQube
- [Group dependencies by their destination.](https://sonarcloud.io/project/issues?branch=develop&open=AYuC83nogesEQUnr3qM_&id=tpambor_MISW4203-Vinilos-App)
- [Do not hardcode version numbers.](https://sonarcloud.io/project/issues?branch=develop&open=AYuC83nogesEQUnr3qNA&id=tpambor_MISW4203-Vinilos-App)
- [A newer version of androidx.navigation:navigation-compose than 2.7.4 is available: 2.7.5](https://sonarcloud.io/project/issues?branch=develop&open=AYuVTlAQ52yOmyC4cZXx&id=tpambor_MISW4203-Vinilos-App)
- [A newer version of androidx.room:room-runtime than 2.5.2 is available: 2.6.0](https://sonarcloud.io/project/issues?branch=develop&open=AYuC83nogesEQUnr3qM-&id=tpambor_MISW4203-Vinilos-App)