### PR TITLE
Refactor: Usar Result<T> en repositories en lugar de null

### DIFF
--- a/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/data/repositories/AlbumRepository.kt
+++ b/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/data/repositories/AlbumRepository.kt
@@ -4,44 +4,50 @@ import android.util.Log
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.VinilosDB
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.models.Album
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.NetworkServiceAdapter
-import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.models.AlbumJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 
 interface IAlbumRepository {
-    fun getAlbums(): Flow<List<Album>?>
-    suspend fun refresh(): Boolean
+    fun getAlbums(): Flow<Result<List<Album>>>
+    suspend fun refresh()
 }
 
 class AlbumRepository : IAlbumRepository {
     private val adapter = NetworkServiceAdapter()
     private val db = VinilosDB.getInstance()
 
-    override fun getAlbums(): Flow<List<Album>?> = flow {
+    override fun getAlbums(): Flow<Result<List<Album>>> = flow {
+        var isFirst = true
+
         db.albumDao().getAlbums().collect { albums ->
-            if (albums.isEmpty()) {
-                if(!refresh()) {
-                    emit(null)
+            if (!isFirst)
+                emit(Result.success(albums))
+
+            // Handle first list returned differently
+            //
+            // If the first list is empty, there is no data in the database.
+            // This is mostly likely due to never have loaded data from the API,
+            // therefore call refresh() in this case to load the data from the API.
+            isFirst = true
+            if(albums.isNotEmpty()) {
+                emit(Result.success(albums))
+            }
+            else {
+                try {
+                    refresh()
+                } catch (ex: Exception) {
+                    Log.e(TAG, "Error loading albums: $ex")
+                    emit(Result.failure(ex))
                 }
-            } else {
-                emit(albums)
             }
         }
     }
 
-    override suspend fun refresh(): Boolean {
-        val albums: List<AlbumJson>
-
-        try {
-            albums = adapter.getAlbums().first()
-        } catch (ex: Exception) {
-            Log.e(TAG, "Error loading albums: $ex")
-            return false
-        }
-
-        db.albumDao().deleteAndInsertAlbums(albums)
-        return true
+    override suspend fun refresh() {
+        db.albumDao().deleteAndInsertAlbums(
+            adapter.getAlbums().first()
+        )
     }
 
     companion object {

--- a/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/data/repositories/CollectorRepository.kt
+++ b/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/data/repositories/CollectorRepository.kt
@@ -2,60 +2,50 @@ package co.edu.uniandes.misw4203.equipo11.vinilos.data.repositories
 
 import android.util.Log
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.VinilosDB
-import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.models.Collector
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.models.CollectorWithPerformers
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.NetworkServiceAdapter
-import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.models.CollectorJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 
 interface ICollectorRepository {
-    fun getCollectors(): Flow<List<Collector>?>
-    fun getCollectorsWithFavoritePerformers(): Flow<List<CollectorWithPerformers>?>
-    suspend fun refresh(): Boolean
+    fun getCollectorsWithFavoritePerformers(): Flow<Result<List<CollectorWithPerformers>>>
+    suspend fun refresh()
 }
 
 class CollectorRepository : ICollectorRepository {
     private val adapter = NetworkServiceAdapter()
     private val db = VinilosDB.getInstance()
 
-    override fun getCollectors(): Flow<List<Collector>?> = flow {
-        db.collectorDao().getCollectors().collect { collectors ->
-            if (collectors.isEmpty()) {
-                if(!refresh()) {
-                    emit(null)
-                }
-            } else {
-                emit(collectors)
-            }
-        }
-    }
+    override fun getCollectorsWithFavoritePerformers(): Flow<Result<List<CollectorWithPerformers>>> = flow {
+        var isFirst = true
 
-    override fun getCollectorsWithFavoritePerformers(): Flow<List<CollectorWithPerformers>?> = flow {
         db.collectorDao().getCollectorsWithPerformers().collect { collectors ->
-            if (collectors.isEmpty()) {
-                if(!refresh()) {
-                    emit(null)
+            if (!isFirst)
+                emit(Result.success(collectors))
+
+            // Handle first list returned differently
+            //
+            // If the first list is empty, there is no data in the database.
+            // This is mostly likely due to never have loaded data from the API,
+            // therefore call refresh() in this case to load the data from the API.
+            isFirst = true
+            if(collectors.isNotEmpty()) {
+                emit(Result.success(collectors))
+            }
+            else {
+                try {
+                    refresh()
+                } catch (ex: Exception) {
+                    Log.e(TAG, "Error loading albums: $ex")
+                    emit(Result.failure(ex))
                 }
-            } else {
-                emit(collectors)
             }
         }
     }
 
-    override suspend fun refresh(): Boolean {
-        val collectors: List<CollectorJson>
-
-        try {
-            collectors = adapter.getCollectors().first()
-        } catch (ex: Exception) {
-            Log.e(TAG, "Error loading Collectors: $ex")
-            return false
-        }
-
-        db.collectorDao().deleteAndInsertCollectors(collectors)
-        return true
+    override suspend fun refresh() {
+        db.collectorDao().deleteAndInsertCollectors(adapter.getCollectors().first())
     }
 
     companion object {

--- a/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/data/repositories/PerformerRepository.kt
+++ b/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/data/repositories/PerformerRepository.kt
@@ -1,11 +1,8 @@
 package co.edu.uniandes.misw4203.equipo11.vinilos.data.repositories
 import android.util.Log
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.VinilosDB
-import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.models.Album
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.database.models.Performer
 import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.NetworkServiceAdapter
-import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.models.BandJson
-import co.edu.uniandes.misw4203.equipo11.vinilos.data.network.models.MusicianJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow

--- a/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/ui/viewmodels/PerformerListViewModel.kt
+++ b/app/src/main/java/co/edu/uniandes/misw4203/equipo11/vinilos/ui/viewmodels/PerformerListViewModel.kt
@@ -47,12 +47,15 @@ class PerformerListViewModel(
         viewModelScope.launch {
             performerRepository.getMusicians()
                 .collect { musicians ->
-                    if (musicians == null) {
-                        _error.value = ErrorUiState.Error(R.string.network_error)
-                    } else {
-                        _musicians.value = musicians
-                        _error.value = ErrorUiState.NoError
-                    }
+                    musicians
+                        .onFailure {
+                            _error.value = ErrorUiState.Error(R.string.network_error)
+                        }
+                        .onSuccess {
+                            _musicians.value = it
+                            _error.value = ErrorUiState.NoError
+                        }
+
                     _isRefreshing.value = false
                 }
         }
@@ -65,12 +68,15 @@ class PerformerListViewModel(
         viewModelScope.launch {
             performerRepository.getBands()
                 .collect { bands ->
-                    if (bands == null) {
-                        _error.value = ErrorUiState.Error(R.string.network_error)
-                    } else {
-                        _bands.value = bands
-                        _error.value = ErrorUiState.NoError
-                    }
+                    bands
+                        .onFailure {
+                            _error.value = ErrorUiState.Error(R.string.network_error)
+                        }
+                        .onSuccess {
+                            _bands.value = it
+                            _error.value = ErrorUiState.NoError
+                        }
+
                     _isRefreshing.value = false
                 }
         }
@@ -99,7 +105,9 @@ class PerformerListViewModel(
         _error.value = ErrorUiState.NoError
 
         viewModelScope.launch {
-            if (!performerRepository.refreshMusicians()) {
+            try {
+                performerRepository.refreshMusicians()
+            } catch (ex: Exception) {
                 _isRefreshing.value = false
                 _error.value = ErrorUiState.Error(R.string.network_error)
             }
@@ -111,7 +119,9 @@ class PerformerListViewModel(
         _error.value = ErrorUiState.NoError
 
         viewModelScope.launch {
-            if (!performerRepository.refreshBands()) {
+            try {
+                performerRepository.refreshBands()
+            } catch (ex: Exception) {
                 _isRefreshing.value = false
                 _error.value = ErrorUiState.Error(R.string.network_error)
             }

--- a/app/src/test/java/co/edu/uniandes/misw4203/equipo11/vinilos/AlbumListViewModelTest.kt
+++ b/app/src/test/java/co/edu/uniandes/misw4203/equipo11/vinilos/AlbumListViewModelTest.kt
@@ -24,20 +24,21 @@ import java.time.Instant
 
 class AlbumListViewModelTest {
     class FakeAlbumRepository: IAlbumRepository {
-        private val flow = MutableSharedFlow<List<Album>?>()
-        suspend fun emit(value: List<Album>?) = flow.emit(value)
+        private val flow = MutableSharedFlow<Result<List<Album>>>()
+        suspend fun emit(value: Result<List<Album>>) = flow.emit(value)
 
         var failRefresh = false
         var refreshCalled = false
 
-        override fun getAlbums(): Flow<List<Album>?> {
+        override fun getAlbums(): Flow<Result<List<Album>>> {
             return flow
         }
 
-        override suspend fun refresh(): Boolean {
+        override suspend fun refresh() {
             refreshCalled = true
 
-            return !failRefresh
+            if (failRefresh)
+                throw Exception()
         }
     }
 
@@ -90,7 +91,7 @@ class AlbumListViewModelTest {
         assertEquals(ErrorUiState.NoError, viewModel.error.first())
 
         // Repository emits albums
-        repository.emit(data)
+        repository.emit(Result.success(data))
 
         // Then, list of albums is filled with the data
         assertEquals(data, viewModel.albums.first())
@@ -112,8 +113,8 @@ class AlbumListViewModelTest {
         assertEquals(emptyList<Album>(), viewModel.albums.first())
         assertEquals(ErrorUiState.NoError, viewModel.error.first())
 
-        // Repository emits null (unable to fetch data)
-        repository.emit(null)
+        // Repository emits failure
+        repository.emit(Result.failure(Exception()))
 
         // Then, list of albums is filled with the data
         assertEquals(emptyList<Album>(), viewModel.albums.first())

--- a/app/src/test/java/co/edu/uniandes/misw4203/equipo11/vinilos/PerformerListViewModelTest.kt
+++ b/app/src/test/java/co/edu/uniandes/misw4203/equipo11/vinilos/PerformerListViewModelTest.kt
@@ -40,7 +40,6 @@ class PerformerListViewModelTest {
 
         suspend fun emitMusicians(value: Result<List<Performer>>) = musiciansFlow.emit(value)
         suspend fun emitBands(value: Result<List<Performer>>) = bandsFlow.emit(value)
-        suspend fun emitFavorites(value: List<Performer>) = favoritesFlow.emit(value)
 
         override fun getMusicians(): Flow<Result<List<Performer>>> = musiciansFlow
         override fun getBands(): Flow<Result<List<Performer>>> = bandsFlow
@@ -62,17 +61,12 @@ class PerformerListViewModelTest {
 
     class FakeUserRepository: IUserRepository {
         private val flow = MutableSharedFlow<User?>()
-        suspend fun emit(value: User?) = flow.emit(value)
-
-        var loginCalled = false
 
         override fun getUser(): Flow<User?> {
             return flow
         }
 
-        override suspend fun login(userType: UserType) {
-            loginCalled = true
-        }
+        override suspend fun login(userType: UserType) { }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Usar Result<T> en repositories en lugar de retornar null al tener un error cargando datos del API.

Así, la semántica es más clara, lo que mejora la mantenibilidad del código. Además, se expone información sobre el tipo de error.

Resuelve 3 warnings reportados por Android Lint
- Function "emit" is never used
- Function "emitFavorites" is never used
- Property "loginCalled" could be private
